### PR TITLE
[API-268] values: Add new route for webhooks.circleci.com

### DIFF
--- a/values.yml
+++ b/values.yml
@@ -55,6 +55,14 @@ service:
       #    port: 8090
       #    nodePort: 30152
 
+kong:
+  routes:
+    - host: webhooks.circleci.com
+      port: 8080
+      paths:
+        - /slackdeskmate
+
+# TODO API-268: Remove after migration to Kong.
 traefik:
   rules:
     - host: slackdeskmatehook.circleci.com


### PR DESCRIPTION
Traefik is being deprecated and services are moving to api-gateway. This
is also an opportunity to consolidate the sub-domains that are use, by
moving similar functioning services onto shared sub-domains, so that:

- there's a lower barrier for entry for new services
- common features can be applied to related services
- it's easier to see how external traffic gets routed to us

There are 3 ITD services that look like webhooks because they only
receive inbound data. So they can move to `webhook.circleci.com`:

- https://circleci.atlassian.net/wiki/spaces/ITD/pages/6329565803/API+Gateway#Available-Subdomains

CCC enables `stripPath` by default so the prefix path will be removed
from the request that makes it to the service. I've removed "hook" from
any paths names, when copying them from the previous sub-domains,
because it's now implied by the new sub-domain.

Once this is merged then we can:

- test the new route in parallel
- migrate clients over to the new route
- remove the old route
- remove DNS

---

Please consider when reviewing:

- does the naming make sense to you?
- is the migration of clients feasible?